### PR TITLE
`mutectrl msg add --mail-input` (for Mutt)

### DIFF
--- a/contrib/mutt/MuteSend.sh
+++ b/contrib/mutt/MuteSend.sh
@@ -7,7 +7,7 @@ msgfile=$(mktemp)
 cat - > ${msgfile}
 exec 3<~/.config/mute/passphrase.f ; mutectrl contact add --id "${username}" --contact "${tonym}" 2>> /tmp/sendlog >> /tmp/sendlog
 exec 3<~/.config/mute/passphrase.f ; mutectrl msg add --from "${username}" --to "${tonym}" --file ${msgfile} 2>> /tmp/sendlog >> /tmp/sendlog
-echo "mutectrl msg add --from "${username}" --to "${tonym}" --file ${msgfile}" 2>> /tmp/sendlog >> /tmp/sendlog
+echo "mutectrl msg add --from "${username}" --mail-input --file ${msgfile}" 2>> /tmp/sendlog >> /tmp/sendlog
 rm ${msgfile}
 exec 3<~/.config/mute/passphrase.f ; mutectrl msg send --id "${username}" 2>> /tmp/sendlog >> /tmp/sendlog
 exit 0

--- a/ctrlengine/ctrlengine.go
+++ b/ctrlengine/ctrlengine.go
@@ -979,7 +979,13 @@ Tries to register a new user ID with the corresponding key server.
 			Subcommands: []cli.Command{
 				{
 					Name:  "add",
-					Usage: "add a new message to out queue",
+					Usage: "add a new message to outqueue",
+					Description: `
+Add a new message to outqueue.
+If option --mail-input is set the input is parsed as an email message and the
+'To' field is used as recipient and the optional 'Subject' combined with the
+email body as the actual message.
+`,
 					Flags: []cli.Flag{
 						cli.StringFlag{
 							Name:  "from, id",
@@ -992,6 +998,10 @@ Tries to register a new user ID with the corresponding key server.
 						cli.StringFlag{
 							Name:  "file",
 							Usage: "read message from file",
+						},
+						cli.BoolFlag{
+							Name:  "mail-input",
+							Usage: "treat input as email message",
 						},
 						// TODO: implement options
 						/*
@@ -1016,8 +1026,11 @@ Tries to register a new user ID with the corresponding key server.
 						if !interactive && !c.IsSet("from") {
 							return log.Error("option --from is mandatory")
 						}
-						if !c.IsSet("to") {
+						if !c.IsSet("mail-input") && !c.IsSet("to") {
 							return log.Error("option --to is mandatory")
+						}
+						if c.IsSet("mail-input") && c.IsSet("to") {
+							return log.Error("options --to and --mail-input exclude each other")
 						}
 						if err := checkDelayArgs(c); err != nil {
 							return err
@@ -1029,7 +1042,8 @@ Tries to register a new user ID with the corresponding key server.
 					},
 					Action: func(c *cli.Context) {
 						ce.err = ce.msgAdd(c, ce.getID(c), c.String("to"),
-							c.String("file"), c.Bool("permanent-signature"),
+							c.String("file"), c.Bool("mail-input"),
+							c.Bool("permanent-signature"),
 							c.StringSlice("attach"),
 							int32(c.Int("mindelay")), int32(c.Int("maxdelay")),
 							line, ce.fileTable.InputFP)

--- a/ctrlengine/mail/mail.go
+++ b/ctrlengine/mail/mail.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016 Mute Communications Ltd.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package mail implements email input messages in Mute.
+package mail
+
+import (
+	"io"
+	"io/ioutil"
+	"net/mail"
+
+	"github.com/mutecomm/mute/log"
+)
+
+// Parse parses a MIME encoded email for sending with Mute. It returns the
+// intended recipient (parsed from mandatory the 'To' field) and the actual
+// message (combined from the optional 'Subject field' plus the message body).
+// It cannot handle attachments and/or multi-part messages.
+func Parse(r io.Reader) (
+	recipient string,
+	message string,
+	err error,
+) {
+	// read message
+	msg, err := mail.ReadMessage(r)
+	if err != nil {
+		return "", "", log.Error(err)
+	}
+	// parse 'To'
+	recipient = msg.Header.Get("To")
+	if recipient == "" {
+		return "", "", log.Error("mail: 'To' not defined")
+	}
+	// parse 'Subject'
+	subject := msg.Header.Get("Subject")
+	// read body
+	body, err := ioutil.ReadAll(msg.Body)
+	if err != nil {
+		return "", "", log.Error(err)
+	}
+	message = subject + "\n" + string(body)
+	return
+}


### PR DESCRIPTION
Add option --mail-input to `mutectrl msg add` which parses the input as
an email message. The manadatory 'To' header field is used as recipient
and the optional 'Subject' header field combined with the email body as
the actual message.

This allows for a better integration with Mutt and MuteSend.sh is
changed accordingly.